### PR TITLE
Changed cliwt_text based on tenure. Removed HOLD and OPSO from reclim configuration since it's not used by reclaims.

### DIFF
--- a/src/HE.FMS.Middleware.BusinessLogic.Tests/Efin/ReclaimConverterTests.cs
+++ b/src/HE.FMS.Middleware.BusinessLogic.Tests/Efin/ReclaimConverterTests.cs
@@ -114,7 +114,7 @@ public class ReclaimConverterTests
         result.cliwt_batch_ref.Should().BeEmpty();
         result.cliwt_item_sequence.Should().Be(defaultDictionary[nameof(CLI_IW_ILT.cliwt_item_sequence)]);
         result.cliwt_print_sequence.Should().Be(defaultDictionary[nameof(CLI_IW_ILT.cliwt_print_sequence)]);
-        result.cliwt_text.Should().Be(defaultDictionary[nameof(CLI_IW_ILT.cliwt_text)]);
+        result.cliwt_text.Should().Be(defaultDictionary[$"{nameof(CLI_IW_ILT.cliwt_text)}_{request.Application.Tenure}"]);
     }
 
     [Fact]

--- a/src/HE.FMS.Middleware.BusinessLogic.Tests/Factories/PaymentRequestFactory.cs
+++ b/src/HE.FMS.Middleware.BusinessLogic.Tests/Factories/PaymentRequestFactory.cs
@@ -64,7 +64,7 @@ public static class PaymentRequestFactory
                 SchemaName = randomizer.String2(27),
                 Region = randomizer.Enum<Region>(),
                 RevenueIndicator = randomizer.Enum<RevenueIndicator>(),
-                Tenure = randomizer.Enum<Tenure>(),
+                Tenure = randomizer.Enum([Tenure.HomeOwnershipForPeopleWithLongTermDisabilities, Tenure.OlderPersonsSharedOwnership]),
                 VatCode = randomizer.Enum<VatCode>(),
                 VatRate = 23,
             },

--- a/src/HE.FMS.Middleware.BusinessLogic.Tests/Factories/PaymentRequestFactory.cs
+++ b/src/HE.FMS.Middleware.BusinessLogic.Tests/Factories/PaymentRequestFactory.cs
@@ -47,6 +47,7 @@ public static class PaymentRequestFactory
     {
         var randomizer = new Randomizer();
 
+        Tenure[] excludeTenureElements = [Tenure.HomeOwnershipForPeopleWithLongTermDisabilities, Tenure.OlderPersonsSharedOwnership];
         return new ReclaimPaymentRequest
         {
             Reclaim = new ReclaimDetails
@@ -64,7 +65,7 @@ public static class PaymentRequestFactory
                 SchemaName = randomizer.String2(27),
                 Region = randomizer.Enum<Region>(),
                 RevenueIndicator = randomizer.Enum<RevenueIndicator>(),
-                Tenure = randomizer.Enum([Tenure.HomeOwnershipForPeopleWithLongTermDisabilities, Tenure.OlderPersonsSharedOwnership]),
+                Tenure = randomizer.Enum(excludeTenureElements),
                 VatCode = randomizer.Enum<VatCode>(),
                 VatRate = 23,
             },

--- a/src/HE.FMS.Middleware.BusinessLogic/Efin/ReclaimConverter.cs
+++ b/src/HE.FMS.Middleware.BusinessLogic/Efin/ReclaimConverter.cs
@@ -61,7 +61,7 @@ public class ReclaimConverter : PaymentConverter, IReclaimConverter
             cliwt_batch_ref = string.Empty,
             cliwt_item_sequence = defaultDictionary[nameof(CLI_IW_ILT.cliwt_item_sequence)],
             cliwt_print_sequence = defaultDictionary[nameof(CLI_IW_ILT.cliwt_print_sequence)],
-            cliwt_text = defaultDictionary[nameof(CLI_IW_ILT.cliwt_text)],
+            cliwt_text = defaultDictionary[$"{nameof(CLI_IW_ILT.cliwt_text)}_{reclaimPayment.Application.Tenure}"],
         };
     }
 

--- a/src/LookupSeeds/ReclaimDefault.json
+++ b/src/LookupSeeds/ReclaimDefault.json
@@ -25,7 +25,10 @@
     "cliwt_item_sequence": "1",
     "cliwt_print_sequence": "1",
     "cliwt_sub_ledger_id": "SL4",
-    "cliwt_text": "HOUSING FOR RENT GRANT RECLAIM",
+    "cliwt_text_AffordableRent": "AFFORDABLE RENT GRANTS RECLAIMS",
+    "cliwt_text_SocialRent": "SOCIAL RENT GRANT RECLAIMS",
+    "cliwt_text_SharedOwnership": "SHARED OWNERSHIP GRANT RECLAIMS",
+    "cliwt_text_RentToBuy": "RENT TO BUY GRANT RECLAIMS",
     "cliwa_job": "AHP11111",
     "cliwi_job": "AHP11111"
   }

--- a/src/LookupSeeds/TenureLookup.json
+++ b/src/LookupSeeds/TenureLookup.json
@@ -11,8 +11,6 @@
     "Reclaim_AffordableRent": "8241",
     "Reclaim_SocialRent": "8242",
     "Reclaim_SharedOwnership": "8243",
-    "Reclaim_RentToBuy": "8244",
-    "Reclaim_HomeOwnershipForPeopleWithLongTermDisabilities": "7666",
-    "Reclaim_OlderPersonsSharedOwnership": "7666"
+    "Reclaim_RentToBuy": "8244"
   }
 }


### PR DESCRIPTION
Changed cliwt_text based on tenure. Removed HOLD and OPSO from reclim configuration since it's not used by reclaims.